### PR TITLE
N°3366 - Multiple target state on approbal-extended 

### DIFF
--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -90,7 +90,7 @@
         <field id="target_class" xsi:type="AttributeClass">
           <class_category>bizmodel</class_category>
           <sql>target_class</sql>
-          <default_value>UserRequest</default_value>
+          <default_value/>
           <is_null_allowed>false</is_null_allowed>
         </field>
         <field id="target_class_state" xsi:type="AttributeString">

--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -87,6 +87,18 @@
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
         </field>
+        <field id="target_class" xsi:type="AttributeClass">
+          <class_category>bizmodel</class_category>
+          <sql>target_class</sql>
+          <default_value>UserRequest</default_value>
+          <is_null_allowed>false</is_null_allowed>
+        </field>
+        <field id="target_class_state" xsi:type="AttributeString">
+          <sql>target_class_state</sql>
+          <class_field>target_class</class_field>
+          <default_value/>
+          <is_null_allowed>false</is_null_allowed>
+        </field>
         <field id="level1_rule" xsi:type="AttributeOQL">
           <sql>level1_rule</sql>
           <default_value/>
@@ -200,15 +212,21 @@
                 <item id="fieldset:ApprovalRule:baseinfo">
                   <rank>10</rank>
                  <items>
-		    <item id="name">
-		      <rank>10</rank>
-		    </item>
-		    <item id="description">
-		      <rank>20</rank>
-		    </item>
-		    <item id="coveragewindow_id">
-		      <rank>30</rank>
-		    </item>
+                  <item id="name">
+                    <rank>10</rank>
+                  </item>
+                  <item id="description">
+                    <rank>20</rank>
+                  </item>
+                   <item id="target_class">
+                     <rank>30</rank>
+                   </item>
+                   <item id="target_class_state">
+                     <rank>40</rank>
+                   </item>
+                  <item id="coveragewindow_id">
+                    <rank>50</rank>
+                  </item>
                  </items>
                 </item>
               </items>
@@ -279,9 +297,15 @@
             <item id="description">
               <rank>20</rank>
             </item>
-	    <item id="coveragewindow_id">
-	      <rank>30</rank>
-	    </item>
+            <item id="target_class">
+              <rank>30</rank>
+            </item>
+            <item id="target_class_state">
+              <rank>40</rank>
+            </item>
+            <item id="coveragewindow_id">
+              <rank>50</rank>
+            </item>
           </items>
         </search>
         <list>
@@ -342,7 +366,14 @@
           </attributes>
         </reconciliation>
       </properties>
-      <fields/>
+      <fields>
+        <field id="target_class_state" xsi:type="AttributeString">
+          <sql>target_class_state</sql>
+          <class_field>obj_class</class_field>
+          <default_value/>
+          <is_null_allowed>false</is_null_allowed>
+        </field>
+      </fields>
       <methods>
         <method id="GetApprovalScheme">
           <static>true</static>
@@ -355,22 +386,28 @@
 			'first_reject' => ApprovalScheme::EXIT_ON_FIRST_REJECT,
 			'first_approve' => ApprovalScheme::EXIT_ON_FIRST_APPROVE,
 		);
-		if ((get_class($oObject) != 'UserRequest'))
-		{
-			return null;
-		}
-		$sTargetState = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'target_state', 'new');
-		if ($sReachingState != $sTargetState)
+
+		$aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ['UserRequest'=>['target_state'=>'new']]);
+IssueLog::Error('aAllowedClasses'.json_encode($aAllowedClasses));
+if (array_key_exists(get_class($oObject), $aAllowedClasses) === false)
 		{
 			return null;
 		}
 
-		$sOQL = 'SELECT ApprovalRule AS ar JOIN ServiceSubcategory AS sc ON sc.approvalrule_id = ar.id WHERE sc.id = :servicesubcategory';
+		$sTargetState = $aAllowedClasses[get_class($oObject)][ 'target_state'];
+IssueLog::Error('aAllowedClasses $sTargetState'.json_encode($sTargetState));
+		if (in_array($sReachingState, explode(',', $sTargetState)) === false)
+		{
+			return null;
+		}
+
+		$sOQL = 'SELECT ApprovalRule AS ar JOIN ServiceSubcategory AS sc ON sc.approvalrule_id = ar.id WHERE sc.id = :servicesubcategory AND ar.target_class = :target_class AND ar.target_class_state = :target_class_state';
 		$oApprovalRuleSet = new DBObjectSet(
 			DBObjectSearch::FromOQL($sOQL),
 			array(),
-			array('servicesubcategory' => $oObject->Get('servicesubcategory_id'))
-		);
+			['servicesubcategory' => $oObject->Get('servicesubcategory_id'), 'target_class' => get_class($oObject), 'target_class_state' => $sReachingState]);
+    IssueLog::Error('ApprovalRule: '.$oApprovalRuleSet->GetFilter()->ToOQL(true));
+    IssueLog::Error('ApprovalRuleSet count: '.$oApprovalRuleSet->count());
 		if ($oApprovalRuleSet->count() == 0)
 		{
 			// No approval rule applies to the current object
@@ -381,6 +418,8 @@
 
 		$oApprovalRule = $oApprovalRuleSet->fetch();
 		$oScheme = new ExtendedApprovalScheme();
+    $oScheme->Set('target_class_state', $sReachingState);
+    $oScheme->Set('started_state', $sReachingState);
 
     $bStepAdded = false;
 
@@ -551,7 +590,9 @@
 			return false;
 		}
 
-		$sAllowedProfiles = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'bypass_profiles', 'Administrator, Service Manager');
+	  $aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ['UserRequest'=>['bypass_profiles'=>' Administrator, Service Manager']]);
+
+		$sAllowedProfiles = $aAllowedClasses[$this->Get('obj_class')]['bypass_profiles'];
 		$aAllowed = array();
 		foreach (explode(',', $sAllowedProfiles) as $sProfileRaw)
 		{

--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -387,7 +387,7 @@
 		);
 
 		$aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ApprovalConfiguration::DEFAULT_TARGET);
-    if (array_key_exists(get_class($oObject), $aAllowedClasses) === false)		{
+        if (array_key_exists(get_class($oObject), $aAllowedClasses) === false)		{
 			return null;
 		}
 
@@ -399,7 +399,7 @@
 		$sOQL = 'SELECT ApprovalRule AS ar JOIN ServiceSubcategory AS sc ON sc.approvalrule_id = ar.id WHERE sc.id = :servicesubcategory AND ar.target_class = :target_class AND ar.target_class_state = :target_class_state';
 		$oApprovalRuleSet = new DBObjectSet(
 			DBObjectSearch::FromOQL($sOQL),
-			array(),
+			[],
 			['servicesubcategory' => $oObject->Get('servicesubcategory_id'), 'target_class' => get_class($oObject), 'target_class_state' => $sReachingState]);
 
 		if ($oApprovalRuleSet->count() == 0)
@@ -584,7 +584,7 @@
 			return false;
 		}
 
-	  $aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ApprovalConfiguration::DEFAULT_TARGET);
+	    $aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ApprovalConfiguration::DEFAULT_TARGET);
 
 		$sAllowedProfiles = $aAllowedClasses[$this->Get('obj_class')]['bypass_profiles'];
 		$aAllowed = array();

--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -387,17 +387,13 @@
 			'first_approve' => ApprovalScheme::EXIT_ON_FIRST_APPROVE,
 		);
 
-		$aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ['UserRequest'=>['target_state'=>'new']]);
-IssueLog::Error('aAllowedClasses'.json_encode($aAllowedClasses));
-if (array_key_exists(get_class($oObject), $aAllowedClasses) === false)
-		{
+		$aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ApprovalConfiguration::DEFAULT_TARGET);
+    if (array_key_exists(get_class($oObject), $aAllowedClasses) === false)		{
 			return null;
 		}
 
-		$sTargetState = $aAllowedClasses[get_class($oObject)][ 'target_state'];
-IssueLog::Error('aAllowedClasses $sTargetState'.json_encode($sTargetState));
-		if (in_array($sReachingState, explode(',', $sTargetState)) === false)
-		{
+		$aTargetState = $aAllowedClasses[get_class($oObject)][ 'target_states'];
+		if (in_array($sReachingState, $aTargetState) === false)		{
 			return null;
 		}
 
@@ -406,15 +402,14 @@ IssueLog::Error('aAllowedClasses $sTargetState'.json_encode($sTargetState));
 			DBObjectSearch::FromOQL($sOQL),
 			array(),
 			['servicesubcategory' => $oObject->Get('servicesubcategory_id'), 'target_class' => get_class($oObject), 'target_class_state' => $sReachingState]);
-    IssueLog::Error('ApprovalRule: '.$oApprovalRuleSet->GetFilter()->ToOQL(true));
-    IssueLog::Error('ApprovalRuleSet count: '.$oApprovalRuleSet->count());
+
 		if ($oApprovalRuleSet->count() == 0)
 		{
 			// No approval rule applies to the current object
 			return null;
 		}
 
-		$bReusePreviousAnswers = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'reuse_previous_answers', true);
+		$bReusePreviousAnswers = $aAllowedClasses[get_class($oObject)][ 'reuse_previous_answers'];
 
 		$oApprovalRule = $oApprovalRuleSet->fetch();
 		$oScheme = new ExtendedApprovalScheme();
@@ -590,7 +585,7 @@ IssueLog::Error('aAllowedClasses $sTargetState'.json_encode($sTargetState));
 			return false;
 		}
 
-	  $aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ['UserRequest'=>['bypass_profiles'=>' Administrator, Service Manager']]);
+	  $aAllowedClasses = MetaModel::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', ApprovalConfiguration::DEFAULT_TARGET);
 
 		$sAllowedProfiles = $aAllowedClasses[$this->Get('obj_class')]['bypass_profiles'];
 		$aAllowed = array();

--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -95,7 +95,6 @@
         </field>
         <field id="target_class_state" xsi:type="AttributeString">
           <sql>target_class_state</sql>
-          <class_field>target_class</class_field>
           <default_value/>
           <is_null_allowed>false</is_null_allowed>
         </field>

--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -413,8 +413,8 @@
 
 		$oApprovalRule = $oApprovalRuleSet->fetch();
 		$oScheme = new ExtendedApprovalScheme();
-    $oScheme->Set('target_class_state', $sReachingState);
-    $oScheme->Set('started_state', $sReachingState);
+		$oScheme->Set('target_class_state', $sReachingState);
+		$oScheme->Set('started_state', $sReachingState);
 
     $bStepAdded = false;
 

--- a/datamodel.combodo-approval-extended.xml
+++ b/datamodel.combodo-approval-extended.xml
@@ -391,7 +391,7 @@
 			return null;
 		}
 
-		$aTargetState = $aAllowedClasses[get_class($oObject)][ 'target_states'];
+		$aTargetState = $aAllowedClasses[get_class($oObject)]['target_states'];
 		if (in_array($sReachingState, $aTargetState) === false)		{
 			return null;
 		}

--- a/main.combodo-approval-extended.php
+++ b/main.combodo-approval-extended.php
@@ -75,7 +75,7 @@ class HideButtonsPlugin implements iApplicationUIExtension
 	$('button.action[name="next_action"]').hide();
 JS
 					);
-			}
+				}
 			}
 		}
 	}

--- a/main.combodo-approval-extended.php
+++ b/main.combodo-approval-extended.php
@@ -68,7 +68,7 @@ class HideButtonsPlugin implements iApplicationUIExtension
 
 			if (in_array($sTargetState, $aAllowedClasses[get_class($oObject)][ 'target_states']) )		{
 				$sOQL = 'SELECT ApprovalRule AS ar JOIN ServiceSubcategory AS sc ON sc.approvalrule_id = ar.id WHERE ar.target_class = :target_class AND ar.target_class_state = :target_state';
-				$oApprovalRuleSet = new DBObjectSet( DBObjectSearch::FromOQL($sOQL),	[],	['target_class' => get_class($oObject), 'target_states' => $sTargetState]);
+				$oApprovalRuleSet = new DBObjectSet( DBObjectSearch::FromOQL($sOQL),	[],	['target_class' => get_class($oObject), 'target_state' => $sTargetState]);
 				if ($oApprovalRuleSet->Count() > 0) {
 					$oPage->add_ready_script(
 <<<JS

--- a/main.combodo-approval-extended.php
+++ b/main.combodo-approval-extended.php
@@ -71,9 +71,9 @@ class HideButtonsPlugin implements iApplicationUIExtension
 				$oApprovalRuleSet = new DBObjectSet( DBObjectSearch::FromOQL($sOQL),	[],	['target_class' => get_class($oObject), 'target_state' => $sTargetState]);
 				if ($oApprovalRuleSet->Count() > 0) {
 					$oPage->add_ready_script(
-						<<<EOF
+<<<JS
 	$('button.action[name="next_action"]').hide();
-EOF
+JS
 					);
 			}
 			}

--- a/main.combodo-approval-extended.php
+++ b/main.combodo-approval-extended.php
@@ -68,7 +68,7 @@ class HideButtonsPlugin implements iApplicationUIExtension
 
 			if (in_array($sTargetState, $aAllowedClasses[get_class($oObject)][ 'target_states']) )		{
 				$sOQL = 'SELECT ApprovalRule AS ar JOIN ServiceSubcategory AS sc ON sc.approvalrule_id = ar.id WHERE ar.target_class = :target_class AND ar.target_class_state = :target_state';
-				$oApprovalRuleSet = new DBObjectSet( DBObjectSearch::FromOQL($sOQL),	[],	['target_class' => get_class($oObject), 'target_state' => $sTargetState]);
+				$oApprovalRuleSet = new DBObjectSet( DBObjectSearch::FromOQL($sOQL),	[],	['target_class' => get_class($oObject), 'target_states' => $sTargetState]);
 				if ($oApprovalRuleSet->Count() > 0) {
 					$oPage->add_ready_script(
 <<<JS

--- a/module.combodo-approval-extended.php
+++ b/module.combodo-approval-extended.php
@@ -56,12 +56,17 @@ SetupWebPage::AddModule(
 		'doc.manual_setup' => '', // hyperlink to manual setup documentation, if any
 		'doc.more_information' => '', // hyperlink to more information, if any
 
-		'settings' => array(
-			// Module specific settings go here, if any
-			'target_state' => 'new',
-			'bypass_profiles' => 'Administrator, Service Manager',
-			'reuse_previous_answers' => true
-		),
+		'settings' =>
+			[
+				'targets' => [
+					'UserRequest' =>
+						[
+							'target_states' => 'new,assigned',
+							'bypass_profiles' => 'Service Manager',
+							'reuse_previous_answers' => true,
+						],
+				],
+			],
 	)
 );
 

--- a/module.combodo-approval-extended.php
+++ b/module.combodo-approval-extended.php
@@ -79,11 +79,11 @@ if (!class_exists('ApprovalExtendedInstaller'))
 		public static function BeforeWritingConfig(Config $oConfiguration)
 		{
 			if (empty(utils::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', null))
-					&& !empty(utils::GetConfig()->GetModuleSetting('combodo-approval-extended', 'target_state', null) )) {
+					&& !empty(utils::GetConfig()->GetModuleSetting('combodo-approval-extended', 'target_states', null) )) {
 				// Migration of the old configuration to the new one
 				$newConfiguration = [
 													'UserRequest' =>   [
-														'target_states' => [$oConfiguration->GetModuleSetting('combodo-approval-extended', 'target_state', null) ],
+														'target_states' => [$oConfiguration->GetModuleSetting('combodo-approval-extended', 'target_states', null) ],
 														'bypass_profiles' =>$oConfiguration->GetModuleSetting('combodo-approval-extended', 'bypass_profiles', 'Service Manager') ,
 														'reuse_previous_answers' => $oConfiguration->GetModuleSetting('combodo-approval-extended', 'reuse_previous_answers', true) ,
 													]
@@ -91,7 +91,7 @@ if (!class_exists('ApprovalExtendedInstaller'))
 				$oConfiguration->SetModuleSetting('combodo-approval-extended', 'targets', $newConfiguration);
 			}
 			// Replacing old conf parameters value to indicate that it is obsolete
-			$aParamsToRemove = array('target_state', 'bypass_profiles', 'reuse_previous_answers');
+			$aParamsToRemove = array('target_states', 'bypass_profiles', 'reuse_previous_answers');
 			foreach($aParamsToRemove as $sParamToRemove)
 			{
 				$sParamCurrentValue = $oConfiguration->GetModuleSetting('combodo-approval-extended', $sParamToRemove, null);

--- a/module.combodo-approval-extended.php
+++ b/module.combodo-approval-extended.php
@@ -16,7 +16,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'combodo-approval-extended/1.4.2',
+	'combodo-approval-extended/1.5.0-dev',
 	array(
 		// Identification
 		//
@@ -61,7 +61,7 @@ SetupWebPage::AddModule(
 				'targets' => [
 					'UserRequest' =>
 						[
-							'target_states' => 'new,assigned',
+							'target_states' => ['new'],
 							'bypass_profiles' => 'Service Manager',
 							'reuse_previous_answers' => true,
 						],
@@ -78,7 +78,28 @@ if (!class_exists('ApprovalExtendedInstaller'))
 	{
 		public static function BeforeWritingConfig(Config $oConfiguration)
 		{
-			// If you want to override/force some configuration values, do it here
+			if (empty(utils::GetConfig()->GetModuleSetting('combodo-approval-extended', 'targets', null))
+					&& !empty(utils::GetConfig()->GetModuleSetting('combodo-approval-extended', 'target_state', null) )) {
+				// Migration of the old configuration to the new one
+				$newConfiguration = [
+													'UserRequest' =>   [
+														'target_states' => [$oConfiguration->GetModuleSetting('combodo-approval-extended', 'target_state', null) ],
+														'bypass_profiles' =>$oConfiguration->GetModuleSetting('combodo-approval-extended', 'bypass_profiles', 'Service Manager') ,
+														'reuse_previous_answers' => $oConfiguration->GetModuleSetting('combodo-approval-extended', 'reuse_previous_answers', true) ,
+													]
+												];
+				$oConfiguration->SetModuleSetting('combodo-approval-extended', 'targets', $newConfiguration);
+			}
+			// Replacing old conf parameters value to indicate that it is obsolete
+			$aParamsToRemove = array('target_state', 'bypass_profiles', 'reuse_previous_answers');
+			foreach($aParamsToRemove as $sParamToRemove)
+			{
+				$sParamCurrentValue = $oConfiguration->GetModuleSetting('combodo-approval-extended', $sParamToRemove, null);
+				if(!empty($sParamCurrentValue))
+				{
+					$oConfiguration->SetModuleSetting('combodo-approval-extended', $sParamToRemove, 'No longer used, you can remove this parameter.');
+				}
+			}
 			return $oConfiguration;
 		}
 


### PR DESCRIPTION
need change in approval base (branche feature/3366-Add_status_informations_on_approval )

Allows you to configure which classes are affected by the approval and from which statuses. Multiple starting statuses are allowed for a class.

new configuration for this module: 

	_'combodo-approval-extended' => array (
		'targets' => array (
		  'UserRequest' => 
		  array (
		    'target_states' => ['new','assigned'],
		    'bypass_profiles' => 'Service Manager',
		    'reuse_previous_answers' => true,
		  ),
		)
	),_


You can configure different triggers to send different messages for approval:
![image](https://github.com/Combodo/combodo-approval-extended/assets/57360138/5fac57ce-2663-49fb-9d40-ca7f87d6f8dc)

Different approval stages are visible on the object in the Approval tab with the starting and ending status (thanks to the functionality implemented in the approval-base)
![image](https://github.com/Combodo/combodo-approval-extended/assets/57360138/e6666e59-7d99-49af-8a5c-dc0616a64042)
